### PR TITLE
Add Parallel Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 - **[avivl/claude-007-agents](https://github.com/avivl/claude-007-agents):** A unified AI agent orchestration system featuring dozens of specialized agents across 14 categories for modern software development.
 - **[N1nEmAn/acca](https://github.com/N1nEmAn/acca):** A multi-AI collaborative workflow system that lets Antigravity orchestrate Claude CLI and Codex CLI together.
 - **[williamnie/aegisFlow](https://github.com/williamnie/aegisFlow):** A multi-agent workflow that turns an idea into a full PRD and technical design, then orchestrates local toolchains to build it.
+- **[Parallel Code](https://parallelcode.app/):** Desktop app for running Claude Code, Codex CLI, Gemini CLI, and other coding agents in parallel. Each task gets its own git branch and worktree, with diff and merge controls.
 
 <a id="task-memory-workspace"></a>
 ## 🗂️ Task, Memory & Workspace Management


### PR DESCRIPTION
Adds Parallel Code to Multi-Agent Orchestration & Collaboration. It runs several CLI coding agents in parallel, with one branch and worktree per task.